### PR TITLE
cognition_package 1.6.2 published

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 1.6.1
+## 1.6.2
 
 * Upgrade to carp_serialization v. 2.0 - note that we now use **camelCase** for JSON.
+* Support for deserialization of all `RPResult` classes and sub-classes (polymorphic serialization using the `carp_serializable` package) (issue [#83](https://github.com/cph-cachet/research.package/issues/83))
 * Fix of bug in calculating score in Flanker
 * Small updates to demo app
 

--- a/example/lib/cognition_config.dart
+++ b/example/lib/cognition_config.dart
@@ -1,5 +1,4 @@
-import 'package:cognition_package/model.dart';
-import 'package:research_package/model.dart';
+part of 'main.dart';
 
 // Here the list of cognitive test are added to an RP ordered task.
 // Uncomment the ones you want to see a demo of.

--- a/example/lib/cognition_page.dart
+++ b/example/lib/cognition_page.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/material.dart';
-import 'package:research_package/research_package.dart';
-import 'cognition_config.dart';
+part of 'main.dart';
 
 class CognitionPage extends StatelessWidget {
   final int? age;
@@ -37,5 +35,7 @@ class CognitionPage extends StatelessWidget {
       value = value as RPActivityResult;
       print(' $key\t: ${value.results}');
     });
+
+    debugPrint(toJsonString(result));
   }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,13 @@
 import 'package:research_package/research_package.dart';
 import 'package:cognition_package/cognition_package.dart';
 import 'package:flutter/material.dart';
-// import 'package:cognition_package_demo_app/user_demographics_page.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'package:cognition_package_demo_app/cognition_page.dart';
+import 'package:carp_serializable/carp_serializable.dart';
+import 'package:flutter/services.dart';
+
+part 'cognition_config.dart';
+part 'cognition_page.dart';
+part 'user_demographics_page.dart';
 
 Future main() async {
   // Initialize cognition package.

--- a/example/lib/user_demographics_page.dart
+++ b/example/lib/user_demographics_page.dart
@@ -1,6 +1,4 @@
-import 'package:flutter/material.dart';
-import 'package:flutter/services.dart';
-import 'package:cognition_package_demo_app/cognition_page.dart';
+part of 'main.dart';
 
 /// A page for collecting demographics data from test users.
 ///

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
 
   cognition_package:
     path: ../../cognition_package
-  # research_package:
-  #   path: ../../research.package/
+  research_package:
+    path: ../../research.package/
 
 dev_dependencies:
   flutter_lints: any

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,7 +1,6 @@
 name: cognition_package_demo_app
 description: A demo application for the Cognition Package
 publish_to: none
-version: 1.6.0
 
 environment:
   sdk: '>=3.0.6 <4.0.0'
@@ -15,8 +14,8 @@ dependencies:
 
   cognition_package:
     path: ../../cognition_package
-  research_package:
-    path: ../../research.package/
+  # research_package:
+  #   path: ../../research.package/
 
 dev_dependencies:
   flutter_lints: any

--- a/lib/model.g.dart
+++ b/lib/model.g.dart
@@ -554,6 +554,7 @@ RPVisualTrackingResult _$RPVisualTrackingResultFromJson(
     RPVisualTrackingResult(
       identifier: json['identifier'] as String,
     )
+      ..$type = json['__type'] as String?
       ..startDate = json['startDate'] == null
           ? null
           : DateTime.parse(json['startDate'] as String)
@@ -569,9 +570,7 @@ RPVisualTrackingResult _$RPVisualTrackingResultFromJson(
 
 Map<String, dynamic> _$RPVisualTrackingResultToJson(
     RPVisualTrackingResult instance) {
-  final val = <String, dynamic>{
-    'identifier': instance.identifier,
-  };
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -579,6 +578,8 @@ Map<String, dynamic> _$RPVisualTrackingResultToJson(
     }
   }
 
+  writeNotNull('__type', instance.$type);
+  val['identifier'] = instance.identifier;
   writeNotNull('startDate', instance.startDate?.toIso8601String());
   writeNotNull('endDate', instance.endDate?.toIso8601String());
   val['results'] = instance.results;
@@ -591,6 +592,7 @@ RPFlankerResult _$RPFlankerResultFromJson(Map<String, dynamic> json) =>
     RPFlankerResult(
       identifier: json['identifier'] as String,
     )
+      ..$type = json['__type'] as String?
       ..startDate = json['startDate'] == null
           ? null
           : DateTime.parse(json['startDate'] as String)
@@ -605,9 +607,7 @@ RPFlankerResult _$RPFlankerResultFromJson(Map<String, dynamic> json) =>
           .toList();
 
 Map<String, dynamic> _$RPFlankerResultToJson(RPFlankerResult instance) {
-  final val = <String, dynamic>{
-    'identifier': instance.identifier,
-  };
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -615,6 +615,8 @@ Map<String, dynamic> _$RPFlankerResultToJson(RPFlankerResult instance) {
     }
   }
 
+  writeNotNull('__type', instance.$type);
+  val['identifier'] = instance.identifier;
   writeNotNull('startDate', instance.startDate?.toIso8601String());
   writeNotNull('endDate', instance.endDate?.toIso8601String());
   val['results'] = instance.results;
@@ -628,6 +630,7 @@ RPPictureSequenceResult _$RPPictureSequenceResultFromJson(
     RPPictureSequenceResult(
       identifier: json['identifier'] as String,
     )
+      ..$type = json['__type'] as String?
       ..startDate = json['startDate'] == null
           ? null
           : DateTime.parse(json['startDate'] as String)
@@ -643,9 +646,7 @@ RPPictureSequenceResult _$RPPictureSequenceResultFromJson(
 
 Map<String, dynamic> _$RPPictureSequenceResultToJson(
     RPPictureSequenceResult instance) {
-  final val = <String, dynamic>{
-    'identifier': instance.identifier,
-  };
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -653,6 +654,8 @@ Map<String, dynamic> _$RPPictureSequenceResultToJson(
     }
   }
 
+  writeNotNull('__type', instance.$type);
+  val['identifier'] = instance.identifier;
   writeNotNull('startDate', instance.startDate?.toIso8601String());
   writeNotNull('endDate', instance.endDate?.toIso8601String());
   val['results'] = instance.results;
@@ -666,6 +669,7 @@ RPVisualArrayChangeResult _$RPVisualArrayChangeResultFromJson(
     RPVisualArrayChangeResult(
       identifier: json['identifier'] as String,
     )
+      ..$type = json['__type'] as String?
       ..startDate = json['startDate'] == null
           ? null
           : DateTime.parse(json['startDate'] as String)
@@ -681,9 +685,7 @@ RPVisualArrayChangeResult _$RPVisualArrayChangeResultFromJson(
 
 Map<String, dynamic> _$RPVisualArrayChangeResultToJson(
     RPVisualArrayChangeResult instance) {
-  final val = <String, dynamic>{
-    'identifier': instance.identifier,
-  };
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -691,6 +693,8 @@ Map<String, dynamic> _$RPVisualArrayChangeResultToJson(
     }
   }
 
+  writeNotNull('__type', instance.$type);
+  val['identifier'] = instance.identifier;
   writeNotNull('startDate', instance.startDate?.toIso8601String());
   writeNotNull('endDate', instance.endDate?.toIso8601String());
   val['results'] = instance.results;
@@ -703,6 +707,7 @@ RPWordRecallResult _$RPWordRecallResultFromJson(Map<String, dynamic> json) =>
     RPWordRecallResult(
       identifier: json['identifier'] as String,
     )
+      ..$type = json['__type'] as String?
       ..startDate = json['startDate'] == null
           ? null
           : DateTime.parse(json['startDate'] as String)
@@ -717,9 +722,7 @@ RPWordRecallResult _$RPWordRecallResultFromJson(Map<String, dynamic> json) =>
           .toList();
 
 Map<String, dynamic> _$RPWordRecallResultToJson(RPWordRecallResult instance) {
-  final val = <String, dynamic>{
-    'identifier': instance.identifier,
-  };
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -727,6 +730,8 @@ Map<String, dynamic> _$RPWordRecallResultToJson(RPWordRecallResult instance) {
     }
   }
 
+  writeNotNull('__type', instance.$type);
+  val['identifier'] = instance.identifier;
   writeNotNull('startDate', instance.startDate?.toIso8601String());
   writeNotNull('endDate', instance.endDate?.toIso8601String());
   val['results'] = instance.results;
@@ -740,6 +745,7 @@ RPDelayedRecallResult _$RPDelayedRecallResultFromJson(
     RPDelayedRecallResult(
       identifier: json['identifier'] as String,
     )
+      ..$type = json['__type'] as String?
       ..startDate = json['startDate'] == null
           ? null
           : DateTime.parse(json['startDate'] as String)
@@ -755,9 +761,7 @@ RPDelayedRecallResult _$RPDelayedRecallResultFromJson(
 
 Map<String, dynamic> _$RPDelayedRecallResultToJson(
     RPDelayedRecallResult instance) {
-  final val = <String, dynamic>{
-    'identifier': instance.identifier,
-  };
+  final val = <String, dynamic>{};
 
   void writeNotNull(String key, dynamic value) {
     if (value != null) {
@@ -765,6 +769,8 @@ Map<String, dynamic> _$RPDelayedRecallResultToJson(
     }
   }
 
+  writeNotNull('__type', instance.$type);
+  val['identifier'] = instance.identifier;
   writeNotNull('startDate', instance.startDate?.toIso8601String());
   writeNotNull('endDate', instance.endDate?.toIso8601String());
   val['results'] = instance.results;

--- a/lib/model.json.dart
+++ b/lib/model.json.dart
@@ -2,29 +2,40 @@
 //   dart run build_runner build --delete-conflicting-outputs
 part of 'model.dart';
 
-bool _fromJsonFunctionsRegistrered = false;
+bool _fromJsonFunctionsRegistered = false;
 
 /// Register all the fromJson functions for the deployment domain classes.
 void _registerFromJsonFunctions() {
-  if (_fromJsonFunctionsRegistrered) return;
-  _fromJsonFunctionsRegistrered = true;
+  if (_fromJsonFunctionsRegistered) return;
+  _fromJsonFunctionsRegistered = true;
 
   // activity step classes
-  FromJsonFactory()
-      .register(RPContinuousVisualTrackingActivity(identifier: ''));
-  FromJsonFactory().register(RPCorsiBlockTappingActivity(identifier: ''));
-  FromJsonFactory().register(RPDelayedRecallActivity(identifier: ''));
-  FromJsonFactory().register(RPFlankerActivity(identifier: ''));
-  FromJsonFactory().register(RPLetterTappingActivity(identifier: ''));
-  FromJsonFactory()
-      .register(RPPairedAssociatesLearningActivity(identifier: ''));
-  FromJsonFactory().register(RPPictureSequenceMemoryActivity(identifier: ''));
-  FromJsonFactory()
-      .register(RPRapidVisualInfoProcessingActivity(identifier: ''));
-  FromJsonFactory().register(RPReactionTimeActivity(identifier: ''));
-  FromJsonFactory().register(RPStroopEffectActivity(identifier: ''));
-  FromJsonFactory().register(RPTappingActivity(identifier: ''));
-  FromJsonFactory().register(RPTrailMakingActivity(identifier: ''));
-  FromJsonFactory().register(RPVisualArrayChangeActivity(identifier: ''));
-  FromJsonFactory().register(RPWordRecallActivity(identifier: ''));
+  FromJsonFactory().registerAll([
+    RPContinuousVisualTrackingActivity(identifier: ''),
+    RPCorsiBlockTappingActivity(identifier: ''),
+    RPDelayedRecallActivity(identifier: ''),
+    RPFlankerActivity(identifier: ''),
+    RPLetterTappingActivity(identifier: ''),
+    RPPairedAssociatesLearningActivity(identifier: ''),
+    RPPictureSequenceMemoryActivity(identifier: ''),
+    RPRapidVisualInfoProcessingActivity(identifier: ''),
+    RPReactionTimeActivity(identifier: ''),
+    RPStroopEffectActivity(identifier: ''),
+    RPTappingActivity(identifier: ''),
+    RPTrailMakingActivity(identifier: ''),
+    RPVisualArrayChangeActivity(identifier: ''),
+    RPWordRecallActivity(identifier: ''),
+  ]);
+
+  // result classes
+  FromJsonFactory().registerAll(
+    [
+      RPDelayedRecallResult(identifier: ''),
+      RPFlankerResult(identifier: ''),
+      RPPictureSequenceResult(identifier: ''),
+      RPVisualArrayChangeResult(identifier: ''),
+      RPVisualTrackingResult(identifier: ''),
+      RPWordRecallResult(identifier: ''),
+    ],
+  );
 }

--- a/lib/src/result/rp_delayed_recall_result.dart
+++ b/lib/src/result/rp_delayed_recall_result.dart
@@ -25,8 +25,11 @@ class RPDelayedRecallResult extends RPActivityResult {
     return res;
   }
 
+  @override
+  Function get fromJsonFunction => _$RPDelayedRecallResultFromJson;
   factory RPDelayedRecallResult.fromJson(Map<String, dynamic> json) =>
-      _$RPDelayedRecallResultFromJson(json);
+      FromJsonFactory().fromJson<RPDelayedRecallResult>(json);
+
   @override
   Map<String, dynamic> toJson() => _$RPDelayedRecallResultToJson(this);
 }

--- a/lib/src/result/rp_flanker_result.dart
+++ b/lib/src/result/rp_flanker_result.dart
@@ -34,8 +34,10 @@ class RPFlankerResult extends RPActivityResult {
     return res;
   }
 
+  @override
+  Function get fromJsonFunction => _$RPFlankerResultFromJson;
   factory RPFlankerResult.fromJson(Map<String, dynamic> json) =>
-      _$RPFlankerResultFromJson(json);
+      FromJsonFactory().fromJson<RPFlankerResult>(json);
 
   @override
   Map<String, dynamic> toJson() => _$RPFlankerResultToJson(this);

--- a/lib/src/result/rp_picture_sequence_memory_result.dart
+++ b/lib/src/result/rp_picture_sequence_memory_result.dart
@@ -30,8 +30,11 @@ class RPPictureSequenceResult extends RPActivityResult {
     return res;
   }
 
+  @override
+  Function get fromJsonFunction => _$RPPictureSequenceResultFromJson;
   factory RPPictureSequenceResult.fromJson(Map<String, dynamic> json) =>
-      _$RPPictureSequenceResultFromJson(json);
+      FromJsonFactory().fromJson<RPPictureSequenceResult>(json);
+
   @override
   Map<String, dynamic> toJson() => _$RPPictureSequenceResultToJson(this);
 }

--- a/lib/src/result/rp_visual_array_change_result.dart
+++ b/lib/src/result/rp_visual_array_change_result.dart
@@ -28,8 +28,11 @@ class RPVisualArrayChangeResult extends RPActivityResult {
     return res;
   }
 
+  @override
+  Function get fromJsonFunction => _$RPVisualArrayChangeResultFromJson;
   factory RPVisualArrayChangeResult.fromJson(Map<String, dynamic> json) =>
-      _$RPVisualArrayChangeResultFromJson(json);
+      FromJsonFactory().fromJson<RPVisualArrayChangeResult>(json);
+
   @override
   Map<String, dynamic> toJson() => _$RPVisualArrayChangeResultToJson(this);
 }

--- a/lib/src/result/rp_visual_tracking_result.dart
+++ b/lib/src/result/rp_visual_tracking_result.dart
@@ -22,8 +22,10 @@ class RPVisualTrackingResult extends RPActivityResult {
     return res;
   }
 
+  @override
+  Function get fromJsonFunction => _$RPVisualTrackingResultFromJson;
   factory RPVisualTrackingResult.fromJson(Map<String, dynamic> json) =>
-      _$RPVisualTrackingResultFromJson(json);
+      FromJsonFactory().fromJson<RPVisualTrackingResult>(json);
 
   @override
   Map<String, dynamic> toJson() => _$RPVisualTrackingResultToJson(this);

--- a/lib/src/result/rp_word_recall_result.dart
+++ b/lib/src/result/rp_word_recall_result.dart
@@ -27,8 +27,11 @@ class RPWordRecallResult extends RPActivityResult {
     return res;
   }
 
+  @override
+  Function get fromJsonFunction => _$RPWordRecallResultFromJson;
   factory RPWordRecallResult.fromJson(Map<String, dynamic> json) =>
-      _$RPWordRecallResultFromJson(json);
+      FromJsonFactory().fromJson<RPWordRecallResult>(json);
+
   @override
   Map<String, dynamic> toJson() => _$RPWordRecallResultToJson(this);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     sdk: flutter
 
   carp_serializable: ^2.0.0
-  research_package: ^1.7.0
+  research_package: ^1.7.2
   json_annotation: ^4.8.0
   just_audio: ^0.9.34
   reorderables: ^0.6.0
@@ -25,9 +25,9 @@ dev_dependencies:
 
 # Overriding research package to use the local copy
 # Remove this before release of package
-# dependency_overrides:
-#   research_package:
-#     path: ../research.package/
+dependency_overrides:
+  # research_package:
+  #   path: ../research.package/
 
 # auto generate json code (.g files) with:
 #   dart run build_runner build --delete-conflicting-outputs

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cognition_package
 description: A Flutter framework for cognitive testing. Contains 14 pre-defined cognitive tests and an API for creating your own.
-version: 1.6.1
+version: 1.6.2
 homepage: https://github.com/cph-cachet/cognition_package
 
 environment:

--- a/test/json/flanker_result.json
+++ b/test/json/flanker_result.json
@@ -1,0 +1,62 @@
+{
+    "__type": "RPTaskResult",
+    "identifier": "cognition_demo_task",
+    "startDate": "2024-10-24T21:27:16.239577",
+    "results": {
+        "PSM_step": {
+            "__type": "RPActivityResult",
+            "identifier": "PSM_step",
+            "endDate": "2024-10-24T21:27:08.380729",
+            "results": {
+                "result": {
+                    "Amount of moves": [
+                        1
+                    ],
+                    "Amount of correct pairs": [
+                        1
+                    ],
+                    "Time taken to memorize": [
+                        0
+                    ],
+                    "Time taken to move pictures": [
+                        1
+                    ],
+                    "score": 1
+                }
+            },
+            "stepTimes": {
+                "instruction_started": "2024-10-24T21:27:02.987686",
+                "instruction_ended": "2024-10-24T21:27:03.775171",
+                "test_started": "2024-10-24T21:27:03.775295",
+                "test_ended": "2024-10-24T21:27:08.378855",
+                "results_shown": "2024-10-24T21:27:08.381592"
+            },
+            "interactions": []
+        },
+        "flanker_step": {
+            "__type": "RPActivityResult",
+            "identifier": "flanker_step",
+            "endDate": "2024-10-24T21:27:14.233695",
+            "results": {
+                "result": {
+                    "wrong swipes": 5,
+                    "right swipes": 5,
+                    "time": 4,
+                    "score": 0,
+                    "meanCongruent": 239.5,
+                    "meanIncongruent": 394.0,
+                    "numberCardsCongruent": 2,
+                    "numberCardsIncongruent": 3
+                }
+            },
+            "stepTimes": {
+                "instruction_started": "2024-10-24T21:27:09.087316",
+                "instruction_ended": "2024-10-24T21:27:09.794153",
+                "test_started": "2024-10-24T21:27:09.794171",
+                "test_ended": "2024-10-24T21:27:14.231180",
+                "results_shown": "2024-10-24T21:27:14.233816"
+            },
+            "interactions": []
+        }
+    }
+}

--- a/test/json/recall_result.json
+++ b/test/json/recall_result.json
@@ -1,0 +1,42 @@
+{
+    "__type": "RPTaskResult",
+    "identifier": "surveyTaskID",
+    "startDate": "2024-10-24T21:11:13.683736",
+    "results": {
+        "DelayedRecall step ID": {
+            "__type": "RPDelayedRecallResult",
+            "identifier": "DelayedRecall step ID",
+            "results": {},
+            "stepTimes": {},
+            "interactions": []
+        },
+        "Flanker step ID": {
+            "__type": "RPFlankerResult",
+            "identifier": "Flanker step ID",
+            "results": {},
+            "stepTimes": {},
+            "interactions": []
+        },
+        "PictureSequenceMemory step ID": {
+            "__type": "RPPictureSequenceResult",
+            "identifier": "PictureSequenceMemory step ID",
+            "results": {},
+            "stepTimes": {},
+            "interactions": []
+        },
+        "VisualArrayChange step ID": {
+            "__type": "RPVisualArrayChangeResult",
+            "identifier": "VisualArrayChange step ID",
+            "results": {},
+            "stepTimes": {},
+            "interactions": []
+        },
+        "WordRecall step ID": {
+            "__type": "RPWordRecallResult",
+            "identifier": "WordRecall step ID",
+            "results": {},
+            "stepTimes": {},
+            "interactions": []
+        }
+    }
+}

--- a/test/model_json_test.dart
+++ b/test/model_json_test.dart
@@ -158,11 +158,45 @@ void main() {
   });
 
   group('Results', () {
-    test('RPStepResult -> JSON', () {
-      // print((surveyResult!));
-      // print((surveyResult!.toJson()));
+    test('RPTaskResult -> JSON', () {
       print(toJsonString(surveyResult!));
       expect(surveyResult?.results.length, 5);
+    });
+
+    test('JSON -> Recall RPTaskResult', () async {
+      String plainJson =
+          File('test/json/recall_result.json').readAsStringSync();
+
+      final task =
+          RPTaskResult.fromJson(json.decode(plainJson) as Map<String, dynamic>);
+
+      expect(task.$type, task.runtimeType.toString());
+      expect(task.results.values.first.$type, 'RPDelayedRecallResult');
+      print(toJsonString(task));
+
+      // deep assert
+      final taskJson = toJsonString(task);
+      final taskFromJson =
+          RPTaskResult.fromJson(json.decode(taskJson) as Map<String, dynamic>);
+      expect(toJsonString(taskFromJson), equals(taskJson));
+    });
+
+    test('JSON -> Flanker RPTaskResult', () async {
+      String plainJson =
+          File('test/json/flanker_result.json').readAsStringSync();
+
+      final task =
+          RPTaskResult.fromJson(json.decode(plainJson) as Map<String, dynamic>);
+
+      expect(task.$type, task.runtimeType.toString());
+      expect(task.results.values.first.$type, 'RPActivityResult');
+      print(toJsonString(task));
+
+      // deep assert
+      final taskJson = toJsonString(task);
+      final taskFromJson =
+          RPTaskResult.fromJson(json.decode(taskJson) as Map<String, dynamic>);
+      expect(toJsonString(taskFromJson), equals(taskJson));
     });
   });
 }


### PR DESCRIPTION
## 1.6.2

* Upgrade to carp_serialization v. 2.0 - note that we now use **camelCase** for JSON.
* Support for deserialization of all `RPResult` classes and sub-classes (polymorphic serialization using the `carp_serializable` package) (issue [#83](https://github.com/cph-cachet/research.package/issues/83))
* Fix of bug in calculating score in Flanker
* Small updates to demo app